### PR TITLE
Use client cache to reduce the number of client connections

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/controllers/cloudstackcluster_controller.go
+++ b/controllers/cloudstackcluster_controller.go
@@ -39,6 +39,7 @@ import (
 // RBAC permissions used in all reconcilers. Events and Secrets.
 // "" empty string as the api group indicates core kubernetes objects. "*" indicates all objects.
 // +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps;,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
 // RBAC permissions for CloudStackCluster.

--- a/controllers/utils/failuredomains.go
+++ b/controllers/utils/failuredomains.go
@@ -111,8 +111,12 @@ func (c *CloudClientImplementation) AsFailureDomainUser(fdSpec *infrav1.CloudSta
 			return ctrl.Result{}, errors.Wrapf(err, "getting ACSEndpoint secret with ref: %v", fdSpec.ACSEndpoint)
 		}
 
+		clientConfig := &corev1.ConfigMap{}
+		key = client.ObjectKey{Name: cloud.ClientConfigMapName, Namespace: cloud.ClientConfigMapNamespace}
+		_ = c.K8sClient.Get(c.RequestCtx, key, clientConfig)
+
 		var err error
-		if c.CSClient, err = cloud.NewClientFromK8sSecret(endpointCredentials); err != nil {
+		if c.CSClient, err = cloud.NewClientFromK8sSecret(endpointCredentials, clientConfig); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "parsing ACSEndpoint secret with ref: %v", fdSpec.ACSEndpoint)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/cluster-api-provider-cloudstack
 go 1.16
 
 require (
+	github.com/ReneKroon/ttlcache v1.7.0 // indirect
 	github.com/apache/cloudstack-go/v2 v2.13.0
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/ReneKroon/ttlcache v1.7.0 h1:8BkjFfrzVFXyrqnMtezAaJ6AHPSsVV10m6w28N/Fgkk=
+github.com/ReneKroon/ttlcache v1.7.0/go.mod h1:8BGGzdumrIjWxdRx8zpK6L3oGMWvIXdvB2GD1cfvd+I=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -600,6 +602,7 @@ go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0H
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v0.10.0/go.mod h1:VCZuO8V8mFPlL0F5J5GK1rtHV3DrFcQ1R8ryq7FK0aI=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=

--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -67,6 +68,7 @@ type SecretConfig struct {
 }
 
 var clientCache = map[Config]*client{}
+var cacheMutex sync.Mutex
 
 // UnmarshalAllSecretConfigs parses a yaml document for each secret.
 func UnmarshalAllSecretConfigs(in []byte, out *[]SecretConfig) error {
@@ -136,6 +138,9 @@ func NewClientFromYamlPath(confPath string, secretName string) (Client, error) {
 
 // Creates a new Cloud Client form a map of strings to strings.
 func NewClientFromConf(conf Config) (Client, error) {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+
 	if client, exists := clientCache[conf]; exists {
 		return client, nil
 	}

--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -199,10 +199,12 @@ func NewClientFromCSAPIClient(cs *cloudstack.CloudStackClient) Client {
 	return c
 }
 
+// generateClientCacheKey generates a cache key from a Config
 func generateClientCacheKey(conf Config) string {
 	return fmt.Sprintf("%+v", conf)
 }
 
+// newClientCache returns a new instance of client cache
 func newClientCache(clientConfig *corev1.ConfigMap) *ttlcache.Cache {
 	clientCache := ttlcache.NewCache()
 	clientCache.SetTTL(GetClientCacheTTL(clientConfig))
@@ -210,6 +212,7 @@ func newClientCache(clientConfig *corev1.ConfigMap) *ttlcache.Cache {
 	return clientCache
 }
 
+// GetClientCacheTTL returns a client cache TTL duration from the passed config map
 func GetClientCacheTTL(clientConfig *corev1.ConfigMap) time.Duration {
 	var cacheTTL time.Duration
 	if clientConfig != nil {

--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -205,6 +205,12 @@ func generateClientCacheKey(conf Config) string {
 
 func newClientCache(clientConfig *corev1.ConfigMap) *ttlcache.Cache {
 	clientCache := ttlcache.NewCache()
+	clientCache.SetTTL(GetClientCacheTTL(clientConfig))
+	clientCache.SkipTtlExtensionOnHit(false)
+	return clientCache
+}
+
+func GetClientCacheTTL(clientConfig *corev1.ConfigMap) time.Duration {
 	var cacheTTL time.Duration
 	if clientConfig != nil {
 		if ttl, exists := clientConfig.Data[ClientCacheTTLKey]; exists {
@@ -214,7 +220,5 @@ func newClientCache(clientConfig *corev1.ConfigMap) *ttlcache.Cache {
 	if cacheTTL == 0 {
 		cacheTTL = DefaultClientCacheTTL
 	}
-	clientCache.SetTTL(cacheTTL)
-	clientCache.SkipTtlExtensionOnHit(false)
-	return clientCache
+	return cacheTTL
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Instead of creating a client per reconciling, use a client cache to reduce the number of client connections

*Testing performed:*
Created a cluster with 1 CP and 10 workers across two ACS endpoints. With debug output, only two clients were created and the cache clients were used per reconciling


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->